### PR TITLE
remove `clear`

### DIFF
--- a/package_linter.py
+++ b/package_linter.py
@@ -357,9 +357,6 @@ def check_arg_retrieval(script):
 
 
 if __name__ == '__main__':
-    os.system("clear")
-
-
     if len(sys.argv) != 2:
         print("Give one app package path.")
         exit()


### PR DESCRIPTION
it looks clever when you only use package_linter as standalone, but once you run it inside package_check, you loose previous output, which is not dramatic but annoying. A tool should not decide of you clear or not your console. Let's fix this.