### PR TITLE
Report missing or bad manifest arg type, or unecessary 'choices' usage

### DIFF
--- a/package_linter.py
+++ b/package_linter.py
@@ -236,7 +236,7 @@ def check_manifest(path):
 
         for argument in manifest["arguments"]["install"]:
             if not "type" in argument.keys():
-                print_wrong("[YEP-2.1] You should specify the type of the argument '%s'. You can use : %s." % (argument["name"], ', '.join(recognized_types)))
+                print_error("[YEP-2.1] You should specify the type of the argument '%s'. You can use : %s." % (argument["name"], ', '.join(recognized_types)))
             elif argument["type"] not in recognized_types:
                 print_warning("[YEP-2.1] The type '%s' for argument '%s' is not recognized... it probably doesn't behave as you expect ? Choose among those instead : %s" % (argument["type"], argument["name"], ', '.join(recognized_types)))
 

--- a/package_linter.py
+++ b/package_linter.py
@@ -231,13 +231,20 @@ def check_manifest(path):
                 print_warning("[YEP-2.1]" + service + " service may not exist")
 
     if "install" in manifest["arguments"]:
-        types = ("domain", "path", "password", "user", "admin")
 
-        for nbr, typ in enumerate(types):
-            for install_arg in manifest["arguments"]["install"]:
-                if typ == install_arg["name"]:
-                    if "type" not in install_arg:
-                        print_wrong("[YEP-2.1] You should specify the type of the key with %s" % (typ))
+        recognized_types = ("domain", "path", "boolean", "app", "password", "user", "string")
+
+        for argument in manifest["arguments"]["install"]:
+            if not "type" in argument.keys():
+                print_wrong("[YEP-2.1] You should specify the type of the argument '%s'. You can use : %s." % (argument["name"], ', '.join(recognized_types)))
+            elif argument["type"] not in recognized_types:
+                print_warning("[YEP-2.1] The type '%s' for argument '%s' is not recognized... it probably doesn't behave as you expect ? Choose among those instead : %s" % (argument["type"], argument["name"], ', '.join(recognized_types)))
+
+            if "choices" in argument.keys():
+                choices = [ c.lower() for c in argument["choices"] ]
+                if len(choices) == 2:
+                    if ("true" in choices and "false" in choices) or ("yes" in choices and "no" in choices):
+                        print_warning("Argument %s : you might want to simply use a boolean-type argument. No need to specify the choices list yourself." % argument["name"])
 
 
 


### PR DESCRIPTION
The current checks for arguments type (in manifest.json) are a bit weird...

I reworked this part such that it reports : 
- missing argument type (as an error)
- unrecognized argument type (as a warning)
- use of 'choices' only to choose between 'Yes' and 'No' (or True and False). Instead, a boolean arg should be used (better for i18n ?)

This fixes https://github.com/YunoHost/package_linter/issues/2