### PR TITLE
Refactor / clean, and report deprecated practices

### DIFF
--- a/package_linter.py
+++ b/package_linter.py
@@ -132,8 +132,9 @@ def check_source_management(app_path):
         print_warning("[YEP-3.3] Upstream app sources shouldn't be stored on this "
                       "'sources' folder of this git repository as a copy/paste."
                       "\nAt installation, the package should download sources "
-                      "from upstream via 'ynh_setup_source'.\nSee "
-                      "https://dev.yunohost.org/issues/201#Conclusion-chart")
+                      "from upstream via 'ynh_setup_source'.\nSee the helper"
+                      "documentation. Original discussion happened here : "
+                      "https://github.com/YunoHost/issues/issues/201#issuecomment-391549262")
 
 
 def license_mentionned_in_readme(path):

--- a/package_linter.py
+++ b/package_linter.py
@@ -245,7 +245,7 @@ def check_manifest(path):
             descr = descr.get("en", None)
 
         if descr is None or descr == manifest.get("name", None):
-            print_warning("[YEP-1.9] You should write a good description of the""app, at least in english (1 line is enough).")
+            print_warning("[YEP-1.9] You should write a good description of the app, at least in english (1 line is enough).")
 
         elif "for yunohost" in descr.lower():
             print_warning("[YEP-1.9] The 'description' should explain what the app actually does. No need to say that it is 'for YunoHost' - this is a YunoHost app so of course we know it is for YunoHost ;-).")

--- a/package_linter.py
+++ b/package_linter.py
@@ -87,14 +87,15 @@ def check_file_exist(file_path):
 
 def read_file(file_path):
     f = open(file_path)
-    # remove every comments and empty lines from the file content to avoid
-    # false positives
     file = shlex.shlex(f, False)
-    #file = filter(None, re.sub("#.*[^\n]", "", f.read()).splitlines())
     return file
 
 def read_file_raw(file_path):
-    return open(file_path).read()
+    # remove every comments and empty lines from the file content to avoid
+    # false positives
+    f = open(file_path)
+    file = "\n".join(filter(None, re.sub("#.*[^\n]", "", f.read()).splitlines()))
+    return file
 
 
 def check_source_management(app_path):

--- a/package_linter.py
+++ b/package_linter.py
@@ -272,6 +272,9 @@ def check_manifest(path):
                     if "type" not in install_arg:
                         print_error("[YEP-2.1] You should specify the type of the key with %s" % (typ))
 
+    if "url" in manifest and manifest["url"].endswith("_ynh"):
+        print_warning("'url' is not meant to be the url of the yunohost package, but rather the website or repo of the upstream app itself...")
+
 
 def check_verifications_done_before_modifying_system(script):
     """

--- a/package_linter.py
+++ b/package_linter.py
@@ -373,6 +373,14 @@ def check_helper_consistency(script):
             except FileNotFoundError:
                 pass
 
+    if script["name"] == "install" and "yunohost service add" in script["raw"]:
+        try:
+            script2 = read_file_raw(os.path.dirname(script["path"]) + "/remove")
+            if "yunohost service remove" not in script2:
+                print_wrong("You used 'yunohost service add' in the install script, but not 'yunohost service remove' in the remove script.")
+        except FileNotFoundError:
+            pass
+
 
 def check_deprecated_practices(script):
 

--- a/package_linter.py
+++ b/package_linter.py
@@ -238,10 +238,16 @@ def check_manifest(path):
 
     # YEP 1.8 Publish test request
     # YEP 1.9 Document app
-    if "description" in manifest and "name" in manifest:
-        if manifest["description"] == manifest["name"]:
-            print_warning("[YEP-1.9] You should write a good description of the"
-                          "app (1 line is enough).")
+    if "description" in manifest:
+        descr = manifest["description"]
+        if isinstance(descr, dict):
+            descr = descr.get("en", None)
+
+        if descr is None or descr == manifest.get("name", None):
+            print_warning("[YEP-1.9] You should write a good description of the""app, at least in english (1 line is enough).")
+
+        elif "for yunohost" in descr.lower():
+            print_warning("[YEP-1.9] The 'description' should explain what the app actually does. No need to say that it is 'for YunoHost' - this is a YunoHost app so of course we know it is for YunoHost ;-).")
 
     # TODO test a specific template in README.md
 

--- a/package_linter.py
+++ b/package_linter.py
@@ -260,7 +260,8 @@ def check_manifest(path):
 
         for service in manifest["services"]:
             if service not in services:
-                print_warning("[YEP-2.1]" + service + " service may not exist")
+                # FIXME : wtf is it supposed to mean ...
+                print_warning("[YEP-2.1] " + service + " service may not exist")
 
     if "install" in manifest["arguments"]:
         types = ("domain", "path", "password", "user", "admin")
@@ -309,9 +310,9 @@ def check_set_usage(script):
     present = False
 
     if script["name"] in ["backup", "remove"]:
-        present = "ynh_abort_if_errors" in script["raw"] or "set -eu" in script["raw"]
+        present = "ynh_abort_if_errors" in script["shlex"] or "set -eu" in script["raw"]
     else:
-        present = "ynh_abort_if_errors" in script["raw"]
+        present = "ynh_abort_if_errors" in script["shlex"]
 
     if script["name"] == "remove":
         # Remove script shouldn't use set -eu or ynh_abort_if_errors
@@ -423,7 +424,9 @@ def main():
         print_header(script["name"].upper() + " SCRIPT")
 
         script["raw"] = read_file_raw(script["path"])
-        script["shlex"] = read_file_shlex(script["path"])
+        # We transform the shlex thing into a list because the original
+        # object has completely fucked-up behaviors :|.
+        script["shlex"] = [ l for l in read_file_shlex(script["path"]) ]
 
         check_verifications_done_before_modifying_system(script)
         check_set_usage(script)

--- a/package_linter.py
+++ b/package_linter.py
@@ -262,8 +262,9 @@ def check_manifest(path):
             "[YEP-2.1] \"multi_instance\" field must be boolean type values 'true' or 'false' and not string type")
 
     if "services" in manifest:
-        services = ("nginx", "php5-fpm", "mysql", "uwsgi", "metronome",
-                    "postfix", "dovecot")  # , "rspamd", "rmilter")
+        services = ("nginx", "mysql", "uwsgi", "metronome",
+                    "php5-fpm", "php7.0-fpm", "php-fpm", 
+                    "postfix", "dovecot", "rspamd")
 
         for service in manifest["services"]:
             if service not in services:

--- a/package_linter.py
+++ b/package_linter.py
@@ -93,6 +93,9 @@ def read_file(file_path):
     #file = filter(None, re.sub("#.*[^\n]", "", f.read()).splitlines())
     return file
 
+def read_file_raw(file_path):
+    return open(file_path).read()
+
 
 def check_source_management(app_path):
     print(c.BOLD + c.HEADER + "\n>>>> SOURCES MANAGEMENT <<<<" + c.END)
@@ -338,7 +341,7 @@ def check_helper_usage_dependencies(path, script_name):
     Detect usage of ynh_package_* & apt-get *
     and suggest herlpers ynh_install_app_dependencies and ynh_remove_app_dependencies
     """
-    script = read_file(path)
+    script = read_file_raw(path)
 
     if "ynh_package_install" in script or "apt-get install" in script:
         print_warning("You should not use `ynh_package_install` or `apt-get install`, use `ynh_install_app_dependencies` instead")
@@ -353,7 +356,7 @@ def check_helper_usage_unix(path, script_name):
     - rm      → ynh_secure_remove
     - sed -i  → ynh_replace_string
     """
-    script = read_file(path)
+    script = read_file_raw(path)
 
     if "rm -rf" in script or "rm -Rf" in script:
         print_wrong("[YEP-2.12] You should avoid using `rm -rf`, please use `ynh_secure_remove` instead")
@@ -369,12 +372,12 @@ def check_helper_consistency(path, script_name):
     check if ynh_install_app_dependencies is present in install/upgrade/restore
     so dependencies are up to date after restoration or upgrade
     """
-    script = read_file(path)
+    script = read_file_raw(path)
 
     if script_name == "install" and "ynh_install_app_dependencies" in script:
         for name in ["upgrade", "restore"]:
             try:
-                script2 = read_file(os.path.dirname(path) + "/" + name)
+                script2 = read_file_raw(os.path.dirname(path) + "/" + name)
                 if not "ynh_install_app_dependencies" in script2:
                     print_warning("ynh_install_app_dependencies should also be in %s script" % name)
             except FileNotFoundError:
@@ -382,7 +385,7 @@ def check_helper_consistency(path, script_name):
 
 def check_deprecated_practices(path, script_name):
 
-    script = read_file(path)
+    script = read_file_raw(path)
 
     if "yunohost app setting" in script:
         print_warning("'yunohost app setting' shouldn't be used directly. Please use 'ynh_app_setting_(set,get,delete)' instead.")

--- a/package_linter.py
+++ b/package_linter.py
@@ -397,6 +397,8 @@ def check_deprecated_practices(script):
     if "dd if=/dev/urandom" in script["raw"] or "openssl rand" in script["raw"]:
         print_warning("Instead of 'dd if=/dev/urandom' or 'openssl rand', you might want to use ynh_string_random")
 
+    if "systemctl restart nginx" in script["raw"] or "service nginx restart" in script["raw"]:
+        print_wrong("Restarting nginx is quite dangerous (especially for web installs) and should be avoided at all cost. Use 'reload' instead.")
 
 def main():
     if len(sys.argv) != 2:

--- a/package_linter.py
+++ b/package_linter.py
@@ -398,6 +398,9 @@ def check_deprecated_practices(path, script_name):
     if "exit" in script:
         print_warning("'exit' command shouldn't be used. Please use 'ynh_die' instead.")
 
+    if "dd if=/dev/urandom" in script or "openssl rand" in script:
+        print_warning("Instead of 'dd if=/dev/urandom' or 'openssl rand', you might want to use ynh_string_random")
+
     if os.path.exists("%s/../conf/php-fpm.ini" % os.path.dirname(path)):
         print_warning("Using a separate php-fpm.ini file is deprecated. Please merge your php-fpm directives directly in the pool file. (c.f. https://github.com/YunoHost-Apps/nextcloud_ynh/issues/138 )")
 


### PR DESCRIPTION
Meh, I was just implementing new features and just noticed too many weird or buggy things so I'm ending up with this :|.

- I refactored and clean various parts to improve structure and readability
- There were many tests not behaving properly due to the use of shlex ... some of them I still don't understand. Fixed it by checking a raw reading. Maybe that brings false-negative, but at least there should be way less false-positive. We can improve later with regex and stuff like this, or get a better understanding of shlex.
- Added check for use of deprecated practices : 
    - `yunohost app setting`
    - `yunohost app checkurl`
    - `yunohost app checkport`
    - `yunohost app initdb`
    - `exit`
    - separate `php-fpm.ini`
    - `dd if=/dev/urandom` or `openssl rand` for random string generation
- And other check for scary stuff : 
    - `systemctl restart nginx`
    - `yunohost service add` without a corresponding `yunohost service remove`
