### PR TITLE
Warn about the use of add_header in nginx conf

### DIFF
--- a/package_linter.py
+++ b/package_linter.py
@@ -122,6 +122,11 @@ def check_files_exist(app_path):
     if file_exists(app_path + "/conf/php-fpm.ini"):
         print_warning("Using a separate php-fpm.ini file is deprecated. Please merge your php-fpm directives directly in the pool file. (c.f. https://github.com/YunoHost-Apps/nextcloud_ynh/issues/138 )")
 
+    for filename in os.listdir(app_path + "/conf"):
+        content = read_file_raw(app_path + "/conf/" + filename)
+        if "location" in content and "add_header" in content:
+            print_warning("Do not use 'add_header' in the nginx conf. Use 'more_set_headers' instead. (See https://www.peterbe.com/plog/be-very-careful-with-your-add_header-in-nginx and https://github.com/openresty/headers-more-nginx-module#more_set_headers )")
+
 
 def check_source_management(app_path):
     print_header("SOURCES MANAGEMENT")


### PR DESCRIPTION
c.f. https://www.peterbe.com/plog/be-very-careful-with-your-add_header-in-nginx and https://github.com/YunoHost-Apps/nextcloud_ynh/pull/160

Apps should not use `add_header` in nginx conf, but rather `more_set_headers` ... 

This adds a warning in package_linter.