### PR TITLE
Add ability to create issues on Github repo that will flag the app as broken or low quality

### DIFF
--- a/package_linter.py
+++ b/package_linter.py
@@ -476,7 +476,7 @@ class App():
 
         issues = [ i["title"] for i in r if not "pull_request" in i ]
 
-        blocking_issues = [ i for i in issues if i.upper().startswith("[LOW QUALITY]") or i.upper().startswith("[BROKEN]") or i.startswith("E") ]
+        blocking_issues = [ i for i in issues if i.upper().startswith("[LOW QUALITY]") or i.upper().startswith("[BROKEN]") ]
         if blocking_issues:
             print_error("There are important pending issues on the git repo to be solved :\n  - "+"\n  - ".join(blocking_issues))
         else:


### PR DESCRIPTION
There are numerous issues that are too specific or too complex to be detected by the linter. For example : 

- Apps installing docker but not removing it correctly, leading to entire instances having apt broken later
- Apps with clear security issues (e.g. exposing a port through the firewall when it's not actually needed ...)
- Apps that do not respect the spirit of YunoHost (e.g. glowing bear, where you need to manually install weechat (why??), or other apps where you're supposed to finish the installation yourself)
- Apps editing nginx configuration manually
- etc...

Yet, we should have a mechanism to be able to cap the level of these apps ... So this PR introduces a mechanism where : 
- it checks that the app exists in the YunoHost app's catalog
- gets the corresponding url
- check on the corresponding repo if there are any opened issues starting with `[Low Quality]` or `[Broken]`
- if there are, it will return an error. Also we need to return a special error code in case of Broken such that the app gets flagged as level 0. (Gotta do a PR on package_check to handle this)