### PR TITLE
New definitions for level 7, 8 (and 9)

### DIFF
--- a/package_linter.py
+++ b/package_linter.py
@@ -1331,6 +1331,8 @@ class Script(TestSuite):
             yield Critical("'yunohost app initdb' is obsolete!!! Please use 'ynh_mysql_setup_db' instead.")
         if self.contains("yunohost tools port-available"):
             yield Critical("'yunohost tools port-available is obsolete!!! Please use 'ynh_port_available' instead.")
+        if self.contains("yunohost app addaccess") or self.contains("yunohost app removeaccess"):
+            yield Warning("'yunohost app addaccess/removeacces' is obsolete. You should use the new permission system to manage accesses.")
         if self.contains("yunohost app list -i") or self.contains("yunohost app list --installed"):
             yield Warning(
                 "Argument --installed ain't needed anymore when using "

--- a/package_linter.py
+++ b/package_linter.py
@@ -190,7 +190,7 @@ class Error(TestReport):
     style = c.FAIL + " ✘ %s" + c.END
 
 class Info(TestReport):
-    style = c.OKBLUE + " ⓘ  %s" + c.END
+    style = " ⓘ  %s" + c.END
 
 class Success(TestReport):
     style = c.OKGREEN + " ☺  %s ♥" + c.END
@@ -358,11 +358,11 @@ class App(TestSuite):
     def qualify_for_level_7(self):
 
         if tests_reports["error"]:
-            print(" Uhoh there are some errors to be fixed :(")
+            _print(" Uhoh there are some errors to be fixed :(")
         elif len(tests_reports["warning"]) > 3:
-            print(" Still some warnings to be fixed :s")
+            _print(" Still some warnings to be fixed :s")
         elif len(tests_reports["warning"]) > 0:
-            print(" Only %s warning remaining! You can do it!" % len(tests_reports["warning"]))
+            _print(" Only %s warning remaining! You can do it!" % len(tests_reports["warning"]))
         else:
             yield Success("Not even a warning! Congratz and thank you for keeping that package up to date with good practices! This app qualifies for level 7!")
 
@@ -374,7 +374,7 @@ class App(TestSuite):
         catalog_infos = self.app_catalog.catalog_infos
         is_maintained = catalog_infos and catalog_infos.get("maintained", True) is True
         if not is_maintained:
-            print("The app is flagged as not maintained in the app catalog")
+            _print("The app is flagged as not maintained in the app catalog")
         elif "qualify_for_level_7" in successes and "is_long_term_good_quality" in successes:
             yield Success("The app is maintained and long-term good quality, and therefore qualifies for level 8!")
 

--- a/package_linter.py
+++ b/package_linter.py
@@ -881,19 +881,24 @@ class Manifest(TestSuite):
         if "license" not in self.manifest:
             return
 
-        license = self.manifest["license"]
+        # Turns out there may be multiple licenses ... (c.f. seafile)
+        licenses = self.manifest["license"].split(",")
 
-        if "nonfree" in license.replace("-", ""):
-            yield Warning("'non-free' apps cannot be integrated in YunoHost's app catalog.")
-            return
+        for license in licenses:
 
-        code_license = '<code property="spdx:licenseId">' + license + '</code>'
+            license = license.strip()
 
-        if code_license not in spdx_licenses():
-            yield Warning(
-                "The license id '%s' is not registered in https://spdx.org/licenses/." % license
-            )
-            return
+            if "nonfree" in license.replace("-", ""):
+                yield Warning("'non-free' apps cannot be integrated in YunoHost's app catalog.")
+                return
+
+            code_license = '<code property="spdx:licenseId">' + license + '</code>'
+
+            if code_license not in spdx_licenses():
+                yield Warning(
+                    "The license id '%s' is not registered in https://spdx.org/licenses/." % license
+                )
+                return
 
     @test()
     def description(self):

--- a/package_linter.py
+++ b/package_linter.py
@@ -411,6 +411,27 @@ class App(TestSuite):
         if has_domain_arg and not file_exists(app.path + "/scripts/change_url"):
             yield Warning("Consider adding a change_url script to support changing where the app is installed")
 
+    @test()
+    def badges_in_readme(app):
+
+        id_ = app.manifest["id"]
+
+        if not file_exists(app.path + "/README.md"):
+            return
+
+        content = open(app.path + "/README.md").read()
+
+        if not "dash.yunohost.org/integration/%s.svg" % id_ in content:
+            yield Warning(
+                "Please add a badge displaying the level of the app in the README.  "
+                "At least something like :\n   "
+                "[![Integration level](https://dash.yunohost.org/integration/%s.svg)](https://dash.yunohost.org/appci/app/%s)\n"
+                "  (but ideally you should check example_ynh for the full set of recommendations !)"
+                % (id_, id_)
+            )
+
+
+
     #######################################
     #  _    _      _                      #
     # | |  | |    | |                     #

--- a/package_linter.py
+++ b/package_linter.py
@@ -624,6 +624,11 @@ class Configurations(TestSuite):
             if not filename.endswith(".service"):
                 continue
 
+            # Some apps only provide an override conf file, which is different
+            # from the full/base service config (c.f. ffsync)
+            if "override" in filename:
+                continue
+
             try:
                 content = open(app.path + "/conf/" + filename).read()
             except Exception as e:

--- a/package_linter.py
+++ b/package_linter.py
@@ -458,8 +458,9 @@ class App(TestSuite):
             helper_req = official_helpers[helper]
             if not validate_version_requirement(helper_req):
                 major_diff = manifest_req[0] > int(helper_req[0])
+                minor_diff = helper_req.startswith(yunohost_version_req)  # This is meant to cover the case where manifest says "3.8" vs. the helper requires "3.8.1"
                 message = "Using official helper %s implies requiring at least version %s, but manifest only requires %s" % (helper, helper_req, yunohost_version_req)
-                yield Error(message) if major_diff else Warning(message)
+                yield Error(message) if major_diff else (Info(message) if minor_diff else Warning(message))
 
 
     @test()

--- a/package_linter.py
+++ b/package_linter.py
@@ -374,7 +374,7 @@ class App(TestSuite):
         catalog_infos = self.app_catalog.catalog_infos
         is_maintained = catalog_infos and catalog_infos.get("maintained", True) is True
         if not is_maintained:
-            _print("The app is flagged as not maintained in the app catalog")
+            _print(" The app is flagged as not maintained in the app catalog")
         elif "qualify_for_level_7" in successes and "is_long_term_good_quality" in successes:
             yield Success("The app is maintained and long-term good quality, and therefore qualifies for level 8!")
 
@@ -1326,8 +1326,8 @@ class Script(TestSuite):
     def sudo(self):
         if self.containsregex(r"sudo \w"):  # \w is here to not match sudo -u, legit use because ynh_exec_as not official yet...
             yield Info(
-                "You should not need to use 'sudo', the self is being run as root. "
-                "(If you need to run a command using a specific user, use 'ynh_exec_as')"
+                "You should not need to use 'sudo', the script is being run as root. "
+                "(If you need to run a command using a specific user, use 'ynh_exec_as' (or 'sudo -u'))"
             )
 
     @test()
@@ -1346,11 +1346,11 @@ class Script(TestSuite):
 
     @test(only=["install"])
     def progression(self):
-        if not self.contains("ynh_print_info") and not self.contains("ynh_script_progression"):
+        if not self.contains("ynh_script_progression"):
             yield Warning(
-                "Please add a few messages for the user, to explain what is going on "
-                "(in friendly, not-too-technical terms) during the installation. "
-                "You can use 'ynh_print_info' or 'ynh_script_progression' for this."
+                "Please add a few messages for the user using 'ynh_script_progression' "
+                "to explain what is going on (in friendly, not-too-technical terms) "
+                "during the installation. (and ideally in scripts remove, upgrade and restore too)"
             )
 
     @test()

--- a/package_linter.py
+++ b/package_linter.py
@@ -184,16 +184,16 @@ class TestReport:
         _print(self.style % self.message)
 
 class Warning(TestReport):
-    style = c.WARNING + "! %s " + c.END
+    style = c.WARNING + " ! %s " + c.END
 
 class Error(TestReport):
-    style = c.FAIL + "✘ %s" + c.END
+    style = c.FAIL + " ✘ %s" + c.END
 
 class Info(TestReport):
-    style = c.OKBLUE + " %s" + c.END
+    style = c.OKBLUE + " ⓘ  %s" + c.END
 
 class Success(TestReport):
-    style = c.OKGREEN + "☺  %s ♥" + c.END
+    style = c.OKGREEN + " ☺  %s ♥" + c.END
 
 
 
@@ -232,7 +232,7 @@ def report_warning_not_reliable(str):
 
 
 def print_happy(str):
-    _print(c.OKGREEN + "☺ ", str, "♥")
+    _print(c.OKGREEN + " ☺ ", str, "♥")
 
 
 def urlopen(url):
@@ -358,11 +358,11 @@ class App(TestSuite):
     def qualify_for_level_7(self):
 
         if tests_reports["error"]:
-            print("Uhoh there are some errors to be fixed :(")
+            print(" Uhoh there are some errors to be fixed :(")
         elif len(tests_reports["warning"]) > 3:
-            print("Still some warnings to be fixed :s")
+            print(" Still some warnings to be fixed :s")
         elif len(tests_reports["warning"]) > 0:
-            print("Only %s warning remaining! You can do it!" % len(test_reports["warning"]))
+            print(" Only %s warning remaining! You can do it!" % len(tests_reports["warning"]))
         else:
             yield Success("Not even a warning! Congratz and thank you for keeping that package up to date with good practices! This app qualifies for level 7!")
 
@@ -1022,7 +1022,7 @@ class AppCatalog(TestSuite):
             subprocess.check_call(["git", "clone", "https://github.com/YunoHost/apps", "./.apps", "--quiet"])
         else:
             subprocess.check_call(["git", "-C", "./.apps", "fetch", "--quiet"])
-            subprocess.check_call(["git", "-C", "./.apps", "reset", "origin/master", "--hard"])
+            subprocess.check_call(["git", "-C", "./.apps", "reset", "origin/master", "--hard", "--quiet"])
 
         open(flagfile, "w").write("")
 
@@ -1140,7 +1140,7 @@ class AppCatalog(TestSuite):
         score = sum([good_quality(infos) for d, infos in history])
         rel_score = int(100 * score / N)
         if rel_score > 90:
-            yield Success("The app is long-term good quality in the catalog ! (Score: %s/100)" % rel_score)
+            yield Success("The app is long-term good quality in the catalog !")
 
 ##################################
 #   _____           _       _    #

--- a/package_linter.py
+++ b/package_linter.py
@@ -880,36 +880,22 @@ class Manifest(TestSuite):
     @test()
     def license(self):
 
-        if not "license" in self.manifest:
+        if "license" not in self.manifest:
             return
-
-        def license_mentionned_in_readme():
-            readme_path = os.path.join(self.path, 'README.md')
-            if os.path.isfile(readme_path):
-                return "LICENSE" in open(readme_path).read()
-            return False
 
         license = self.manifest["license"]
 
-
         if "nonfree" in license.replace("-", ""):
             yield Warning("'non-free' apps cannot be integrated in YunoHost's app catalog.")
-
+            return
 
         code_license = '<code property="spdx:licenseId">' + license + '</code>'
 
-        if license == "free" and not license_mentionned_in_readme():
+        if code_license not in spdx_licenses():
             yield Warning(
-                "Setting the license as 'free' implies to write something about it in "
-                "the README.md. Alternatively, consider using one of the codes available "
-                "on https://spdx.org/licenses/"
+                "The license id '%s' is not registered in https://spdx.org/licenses/." % license
             )
-        elif code_license not in spdx_licenses():
-            yield Warning(
-                "The license id '%s' is not registered in https://spdx.org/licenses/. "
-                "It can be a typo error. If not, you should replace it by 'free' "
-                "or 'non-free' and give some explanations in the README.md." % (license)
-            )
+            return
 
     @test()
     def description(self):

--- a/package_linter.py
+++ b/package_linter.py
@@ -1324,6 +1324,11 @@ class Script(TestSuite):
             )
 
     @test()
+    def normalize_url_path(self):
+        if self.contains("ynh_normalize_url_path"):
+            yield Info("You probably don't need to call ynh_normalize_url_path ... this is only relevant for upgrades from super-old versions (like 3 years ago or so...)")
+
+    @test()
     def safe_rm(self):
         if self.contains("rm -r") or self.contains("rm -R") or self.contains("rm -fr") or self.contains("rm -fR"):
             yield Error("You should not be using 'rm -rf', please use 'ynh_secure_remove' instead")

--- a/package_linter.py
+++ b/package_linter.py
@@ -616,6 +616,25 @@ class Configurations(TestSuite):
             )
 
     @test()
+    def src_file_checksum_type(self):
+
+        app = self.app
+        for filename in os.listdir(app.path + "/conf") if os.path.exists(app.path + "/conf") else []:
+            if not filename.endswith(".src"):
+                continue
+
+            try:
+                content = open(app.path + "/conf/" + filename).read()
+            except Exception as e:
+                yield Warning("Can't open/read %s : %s" % (filename, e))
+                return
+
+            if "SOURCE_SUM_PRG=md5sum" in content:
+                yield Info("%s: Using md5sum checksum is not so great for "
+                        "security. Consider using sha256sum instead." % filename)
+
+
+    @test()
     def systemd_config_specific_user(self):
 
         app = self.app

--- a/package_linter.py
+++ b/package_linter.py
@@ -1357,7 +1357,7 @@ class Script(TestSuite):
 
         # Usage of ynh_script_prorgression with --time or --weight=1 all over the place...
         if self.containsregex(r"ynh_script_progression.*--time"):
-            yield Warning("Using ynh_script_progression --time should only be for calibrating the weight (c.f. --weight). It's not meant to be kept for production versions.")
+            yield Info("Using ynh_script_progression --time should only be for calibrating the weight (c.f. --weight). It's not meant to be kept for production versions.")
 
     @test(ignore=["_common.sh", "backup"])
     def progression_meaningful_weights(self):
@@ -1384,7 +1384,7 @@ class Script(TestSuite):
     @test(only=["install", "_common.sh"])
     def php_deps(self):
         if self.containsregex("dependencies.*php-"):
-            yield Info("You should avoid having dependencies like 'php-foobar'. Instead, specify the exact version you want like 'php7.0-foobar'. Otherwise, the *wrong* version of the dependency may be installed if sury is also installed. Note that for Stretch/Buster/Bullseye/... transition, Yunohost will automatically patch your file so there's no need to care about that.")
+            yield Warning("You should avoid having dependencies like 'php-foobar'. Instead, specify the exact version you want like 'php7.0-foobar'. Otherwise, the *wrong* version of the dependency may be installed if sury is also installed. Note that for Stretch/Buster/Bullseye/... transition, Yunohost will automatically patch your file so there's no need to care about that.")
 
     @test(only=["backup"])
     def systemd_during_backup(self):

--- a/package_linter.py
+++ b/package_linter.py
@@ -1413,6 +1413,18 @@ class Script(TestSuite):
                 "during the installation. (and ideally in scripts remove, upgrade and restore too)"
             )
 
+    @test(only=["backup"])
+    def progression_in_backup(self):
+        if self.contains("ynh_script_progression"):
+            yield Info(
+                "We recommend to *not* use 'ynh_script_progression' in backup "
+                "scripts because no actual work happens when running the script "
+                " : yunohost only fetches the list of things to backup (apart "
+                "from the DB dumps which effectively happens during the script..). "
+                "Consider using a simple message like this instead: 'ynh_print_info \"Declaring files to be backed up...\"'"
+            )
+
+
     @test()
     def progression_time(self):
 


### PR DESCRIPTION
Sooooo this is yet another me-being-obsessed-with-quality-metrics-and-tools™, and kind of a follow up of last meeting where I was mentioning the idea of redefining level 7 and 8.

This PR proposes to add two new "meta" tests.

First one is the "long-term good-quality score", which is computed by analyzing the history of apps.json over the last 12 months and checking how many periods the app was known + flagged working + level >= 5. If that's the case for 90% of the periods, the app is considered as "long-term good quality" (all the parameters are debatable of course - maybe one year is too much ...)

(N.B. : this got updated compared to original post)

A new definition for level 7 and 8 is proposed : 
- "New" Level 7 = (previous level 7 requirements) + No error / warnings reported by the linter
- "New" Level 8 = Maintained + Long-term high quality
- "New" Level 9 = Remaining parts of the previous level 8 requirements not covered by the new level 8 (c.f. development workflow, ARM, SSO/LDAP)

Some not-that-important warnings were downgraded to just "Info" to avoid "polluting" the new Level 7 definition. (The 'is_maintained' test is handled in some independent way because it's only part of the level 8 and we don't want to e.g. raise a warning which would interfere with the definition of level 7)

Here are the results when running on all apps : 
- about 56 apps qualify for the new level 7
- about 24 apps qualify for the new level 8 (the flag "maintained" ain't reported in the table, but it might be the reason some apps do not qualify for level 8)

| App   |  # of warnings+errors | Qualify for "new level 7" | Long term good quality | Qualify for "new level 8" |
| ----    | ------------------------      | -------------    | ------------------------------  | -------------------------------- |
| 20euros | 0 | True |  |  |
| 243 | 0 | True |  |  |
| adminer | 0 | True |  |  |
| agendav | 0 | True |  |  |
| airsonic | 3 |  | True |  |
| ampache | 1 |  |  |  |
| anarchism | 2 |  | True |  |
| anfora | 4 |  |  |  |
| archivist | 2 |  | True |  |
| backdrop | 0 | True |  |  |
| baikal | 0 | True |  |  |
| bibliogram | 1 |  |  |  |
| bitwarden | 3 |  |  |  |
| blogotext | 1 |  | True |  |
| bludit | 0 | True |  |  |
| borg | 8 |  | True |  |
| borgserver | 5 |  |  |  |
| bozon | 3 |  | True |  |
| cachet | 0 | True |  |  |
| calibreweb | 3 |  | True |  |
| cesium | 0 | True |  |  |
| cheky | 3 |  | True |  |
| civicrm_drupal7 | 0 | True | True | True |
| codimd | 0 | True |  |  |
| couchpotato | 5 |  |  |  |
| cowyo | 2 |  |  |  |
| cryptpad | 1 |  |  |  |
| cubiks-2048 | 0 | True |  |  |
| diagramsnet | 0 | True |  |  |
| diaspora | 1 |  |  |  |
| discourse | 2 |  | True |  |
| distbin | 1 |  | True |  |
| dokuwiki | 2 |  | True |  |
| dolibarr | 0 | True | True | True |
| dotclear2 | 1 |  | True |  |
| droppy | 0 | True |  |  |
| drupal | 0 | True | True | True |
| drupal7 | 0 | True | True | True |
| element | 5 |  |  |  |
| etherpad_mypads | 2 |  | True |  |
| fallback | 4 |  | True |  |
| ffsync | 1 |  | True |  |
| firefly-iii | 1 |  |  |  |
| flarum | 1 |  |  |  |
| fluxbb | 1 |  |  |  |
| framaforms | 0 | True |  |  |
| framagames | 2 |  |  |  |
| freshrss | 0 | True | True | True |
| friendica | 4 |  | True |  |
| funkwhale | 3 |  | True |  |
| garradin | 0 | True | True | True |
| ghost | 2 |  |  |  |
| gitea | 6 |  | True |  |
| gitlab | 0 | True | True | True |
| gitlab-runner | 2 |  | True |  |
| glowingbear | 1 |  |  |  |
| gogs | 7 |  | True |  |
| gotify | 1 |  | True |  |
| grav | 0 | True | True | True |
| h5ai | 1 |  |  |  |
| halcyon | 9 |  |  |  |
| haste | 0 | True |  |  |
| hextris | 0 | True | True | True |
| horde | 8 |  | True |  |
| hubzilla | 2 |  | True |  |
| invoiceninja | 0 | True |  |  |
| jeedom | 6 |  |  |  |
| jenkins | 8 |  |  |  |
| jirafeau | 0 | True | True | True |
| jupyterlab | 2 |  | True |  |
| kanboard | 1 |  | True |  |
| keeweb | 3 |  | True |  |
| kimai2 | 1 |  |  |  |
| kresus | 2 |  | True |  |
| leed | 5 |  | True |  |
| libreto | 4 |  | True |  |
| limesurvey | 7 |  | True |  |
| lionwiki-t2t | 1 |  |  |  |
| lstu | 3 |  | True |  |
| lufi | 1 |  | True |  |
| lutim | 3 |  | True |  |
| mailman | 5 |  | True |  |
| mastodon | 1 |  | True |  |
| matomo | 1 |  | True |  |
| mattermost | 3 |  | True |  |
| meilisearch | 1 |  |  |  |
| minchat | 0 | True |  |  |
| mindmaps | 0 | True |  |  |
| minetest | 5 |  | True |  |
| mobilizon | 0 | True |  |  |
| monica | 0 | True |  |  |
| monitorix | 7 |  | True |  |
| moodle | 1 |  |  |  |
| movim | 1 |  |  |  |
| multi_webapp | 3 |  | True |  |
| mumbleserver | 7 |  | True |  |
| my-mind | 0 | True |  |  |
| my_webapp | 0 | True | True | True |
| navidrome | 1 |  |  |  |
| netdata | 2 |  | True |  |
| nextcloud | 2 |  | True |  |
| nodered | 1 |  | True |  |
| onlyoffice | 0 | True | True | True |
| opensondage | 2 |  | True |  |
| owntracks | 0 | True |  |  |
| peertube | 2 |  | True |  |
| petitesannonces | 0 | True |  |  |
| pgadmin | 5 |  | True |  |
| phpldapadmin | 0 | True | True |  |
| phpmyadmin | 0 | True | True | True |
| phpsysinfo | 0 | True |  |  |
| pihole | 8 |  | True |  |
| pilea | 0 | True |  |  |
| piwigo | 0 | True | True | True |
| pixelfed | 0 | True | True | True |
| pleroma | 1 |  | True |  |
| plume | 0 | True | True | True |
| pluxml | 1 |  | True |  |
| prettynoemiecms | 0 | True | True | True |
| qr | 2 |  | True |  |
| radicale | 9 |  | True |  |
| rainloop | 0 | True | True | True |
| redirect | 2 |  | True |  |
| riot | 7 |  | True |  |
| roundcube | 3 |  |  |  |
| rss-bridge | 0 | True | True | True |
| seafile | 5 |  | True |  |
| searx | 3 |  | True |  |
| shaarli | 3 |  |  |  |
| shellinabox | 4 |  | True |  |
| simple-torrent | 1 |  |  |  |
| slingcode | 0 | True |  |  |
| snipeit | 1 |  | True |  |
| sogo | 6 |  | True |  |
| spftoolbox | 1 |  |  |  |
| spip | 4 |  | True |  |
| streama | 1 |  |  |  |
| strut | 0 | True | True | True |
| svgedit | 0 | True |  |  |
| synapse | 1 |  | True |  |
| syncthing | 1 |  | True |  |
| thelounge | 0 | True | True | True |
| transmission | 7 |  | True |  |
| ttrss | 1 |  | True |  |
| tvheadend | 4 |  | True |  |
| tyto | 0 | True |  |  |
| unattended_upgrades | 1 |  | True |  |
| vpnclient | 3 |  | True |  |
| wallabag2 | 1 |  | True |  |
| webmin | 2 |  |  |  |
| webtrees | 1 |  |  |  |
| wekan | 0 | True | True | True |
| wemawema | 0 | True |  |  |
| wetty | 0 | True |  |  |
| wikijs | 1 |  | True |  |
| wordpress | 2 |  | True |  |
| writefreely | 0 | True | True | True |
| yeswiki | 0 | True |  |  |
| yunomonitor | 4 |  |  |  |
| z-push | 5 |  | True |  |
| zabbix | 7 |  | True |  |
| zap | 2 |  | True |  |
| zerobin | 0 | True | True | True |
| ztncui | 4 |  |  |  |
