### PR TITLE
`set_legacy_permission` to report a warning instead of info

### DIFF
--- a/package_linter.py
+++ b/package_linter.py
@@ -1492,7 +1492,7 @@ class Script(TestSuite):
     @test()
     def set_legacy_permissions(self):
         if self.containsregex(r'ynh_app_setting_set .*protected_') or self.containsregex(r'ynh_app_setting_set .*skipped_'):
-            yield Info("permission system: it looks like the app is still using the legacy permission system (unprotected/protected/skipped uris/regexes setting). Please check https://yunohost.org/packaging_apps_permissions for a documentation on how to migrate the app to the new permission system.")
+            yield Warning("permission system: it looks like the app is still using the legacy permission system (unprotected/protected/skipped uris/regexes setting). Please check https://yunohost.org/packaging_apps_permissions for a documentation on how to migrate the app to the new permission system.")
 
     @test()
     def normalize_url_path(self):


### PR DESCRIPTION
It's now been a while since the release of 4.1 and thanks to the hard work of the packaging team we're down to only a handful of level 7+ apps still reporting this : 

jirafeau
leed
libreto
lstu
lufi
lutim
mailman
privatebin
ttrss

Proposing to switch this to a warning to further encourage getting rid of this legacy ... What got me triggered is somebody encountering the infamous issue on jirafeau with "my domain got a dash which got transformed into a dot and the url permission is found to be invalid, hence install crash" (that's because of the old perm regex format) (though migrating old `protected_regex` is not trivial..)
