### PR TITLE
Add generated files during linter execution in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,11 @@ target/
 # YunoHost packages
 *_ynh
 
+#Generated files during linter execution
+.apps_git_clone_cache
+.spdx_licenses
+.apps/
+
 # Vim swap files
 # *~
 # *.swp


### PR DESCRIPTION
The folder ".apps/" and the files ".spdx_licenses" and ".apps_git_clone_cache" are created during execution of linter, I suggest to add them in .gitignore