### PR TITLE
Change web applications location policy

### DIFF
--- a/package_linter.py
+++ b/package_linter.py
@@ -826,9 +826,11 @@ class App(TestSuite):
     @test()
     def bad_final_path_location(self):
         if os.system(f"grep -q -nr 'ynh_webpath_register' {self.path}/scripts/install 2>/dev/null") == 0 \
-          and os.system(f"grep -q -nr 'final_path=/opt' {self.path}/scripts/install  {self.path}/scripts/_common.sh 2>/dev/null") == 0:
-            yield Info("Web applications are not supposed to be installed in /opt/ ... They are supposed to be installed in /var/www/$app :/")
-
+          and ( os.system(f"grep -q -nr 'final_path=/opt' {self.path}/scripts/install {self.path}/scripts/_common.sh 2>/dev/null") == 0 \
+                and os.system(f"grep -q -nr 'proxy_pass' {self.path}/conf/*nginx.conf 2>/dev/null") != 0 ) \
+          or    os.system(f"grep -q -nr 'final_path=/var/www' {self.path}/scripts/install {self.path}/scripts/_common.sh 2>/dev/null") == 0 :
+            yield Info("Web applications relying on NGINX to serve static or PHP files should go in /var/www/$app, while \
+                        web applications relying on their own web server proxied by NGINX should go in /opt/yunohost/$app.")
 
     @test()
     def app_data_in_unofficial_dir(self):


### PR DESCRIPTION
So, it's a bit opinionated, but I prefer the webapp location policy from before December 2021:

* Web applications which serve static and PHP files via NGINX should go in `/var/www/$app`
* Web applications which rely on NGINX to proxy their own webserver running as a service should go in `/opt`, usually `/opt/yunohost/$app`

Supporting documentation:
> /var contains variable data files. This includes spool directories and files, administrative and logging data, and transient and temporary files.

(source : https://www.pathname.com/fhs/2.2/fhs-5.1.html)
From that phrasing, I feel no binary should be installed in there, only data file. (Remains the case of `composer`, I know...)

> /opt is reserved for the installation of add-on application software packages.
A package to be installed in /opt must locate its static files in a separate /opt/<package> directory tree, where <package> is a name that describes the software package.

(source: https://www.pathname.com/fhs/2.2/fhs-3.12.html)
"add-on application software packages" being a verbose way of saying non-system, user-installed software.

> If the app uses NGINX as web server (written in HTML/PHP in most cases), the final path should be "/var/www/$app".
If the app provides an internal web server (or uses another application server such as uWSGI), the final path should be "/opt/yunohost/$app"

(source: our own `example_ynh` https://github.com/YunoHost/example_ynh/blob/master/scripts/install#L59-L60)

---

This may be thrown out in the future, especially if we move to storing all apps in a dedicated `.../yunohost` directory.

- [ ] Python code checked and tested