### PR TITLE
Use an Info instead of a Warning for packages that are not in the YunoHost-Apps organisation

### DIFF
--- a/package_linter.py
+++ b/package_linter.py
@@ -1755,7 +1755,7 @@ class AppCatalog(TestSuite):
                         "The URL for this app in the catalog should be %s" % repo_org
                     )
                 else:
-                    yield Warning(
+                    yield Info(
                         "Consider adding your app to the YunoHost-Apps organization to allow the community to contribute more easily"
                     )
 
@@ -1768,7 +1768,7 @@ class AppCatalog(TestSuite):
                 return urlopen(repo_brique)["code"] != 404
 
             if not is_in_github_org() and not is_in_brique_org():
-                yield Warning(
+                yield Info(
                     "Consider adding your app to the YunoHost-Apps organization to allow the community to contribute more easily"
                 )
 


### PR DESCRIPTION
- Fix https://github.com/YunoHost/issues/issues/1964