### PR TITLE
Fix package linter on apt list

### DIFF
--- a/package_linter.py
+++ b/package_linter.py
@@ -1964,7 +1964,11 @@ class Manifest(TestSuite):
                     )
 
                 dbtype = resources["database"]["type"]
-                apt_packages = [p.strip(',') for p in resources["apt"].get("packages", "").split(" ")]
+
+                apt_packages = resources["apt"].get("packages", [])
+                if isinstance(apt_packages, str):
+                    apt_packages = [value.strip() for value in apt_packages.split(",")]
+
                 if dbtype == "mysql" and "mariadb-server" not in apt_packages:
                     yield Warning(
                         "When using a mysql database, you should add mariadb-server in apt dependencies. Even though it's currently installed by default in YunoHost installations, it might not be in the future !"


### PR DESCRIPTION
Allow packages to be a list. Also, use the same splitting logic as in yunohost source code.