### PR TITLE
Consistently parse apt dependencies.

### DIFF
--- a/package_linter.py
+++ b/package_linter.py
@@ -1967,7 +1967,7 @@ class Manifest(TestSuite):
 
                 apt_packages = resources["apt"].get("packages", [])
                 if isinstance(apt_packages, str):
-                    apt_packages = [value.strip() for value in apt_packages.split(",")]
+                    apt_packages = [value.strip() for value in re.split(' |,',apt_packages)]
 
                 if dbtype == "mysql" and "mariadb-server" not in apt_packages:
                     yield Warning(


### PR DESCRIPTION
Make "x y" proper list of dependencies [`x`, `y`]  rather that of [`x y`]