### PR TITLE
add bind_public_ip check

### DIFF
--- a/package_linter.py
+++ b/package_linter.py
@@ -1550,7 +1550,7 @@ class Configurations(TestSuite):
                     and not line.strip().startswith(comment)
                 ):
                     for ip in re.split("[ \t,='\"(){}\[\]]", line):
-                        if ip == "::" or "0.0.0.0" in ip:
+                        if ip == "::" or ( "0.0.0.0" in ip and ip.startswith("0.0.0.0") ):
                             yield Info(
                                 f"{filename}:{number}: Binding to '0.0.0.0' or '::' can result "
                                 "in a security issue as the reverse proxy and the SSO can be "

--- a/package_linter.py
+++ b/package_linter.py
@@ -1543,18 +1543,17 @@ class Configurations(TestSuite):
                 yield Warning("Can't open/read %s: %s" % (filename, e))
                 return
 
-            for line in content.split("\n"):
-                comment = ["#", "//", ";"]
+            for number, line in enumerate(content.split("\n"), 1):
+                comment = ("#", "//", ";")
                 if (
-                    "0.0.0.0" in line
-                    or "::" in line
+                    ( "0.0.0.0" in line or "::" in line )
                     and not line.strip().startswith(comment)
                 ):
                     yield Info(
-                        "%s: Binding to '0.0.0.0' or '::' can result in a security issue as "
-                        "the SSO can be bypassed by knowing a public IP (typically an IPv6) "
-                        "and the app port. Please be sure that this behavior is intentional.\n"
-                        "Maybe use '127.0.0.1' or '::1' instead." % filename
+                        f"{filename}:{number}: Binding to '0.0.0.0' or '::' can result in "
+                        "a security issue as the SSO can be bypassed by knowing a public "
+                        "IP (typically an IPv6) and the app port. Please be sure that this "
+                        "behavior is intentional. Maybe use '127.0.0.1' or '::1' instead."
                     )
 
 #############################################

--- a/package_linter.py
+++ b/package_linter.py
@@ -1549,13 +1549,15 @@ class Configurations(TestSuite):
                     ( "0.0.0.0" in line or "::" in line )
                     and not line.strip().startswith(comment)
                 ):
-                    yield Info(
-                        f"{filename}:{number}: Binding to '0.0.0.0' or '::' can result "
-                        "in a security issue as the reverse proxy and the SSO can be "
-                        "bypassed by knowing a public IP (typically an IPv6) and the "
-                        "app port. lease be sure that this behavior is intentional. "
-                        "Maybe use '127.0.0.1' or '::1' instead."
-                    )
+                    for ip in re.split("[ \t,='\"(){}\[\]]", line):
+                        if ip == "::" or "0.0.0.0" in ip:
+                            yield Info(
+                                f"{filename}:{number}: Binding to '0.0.0.0' or '::' can result "
+                                "in a security issue as the reverse proxy and the SSO can be "
+                                "bypassed by knowing a public IP (typically an IPv6) and the "
+                                "app port. lease be sure that this behavior is intentional. "
+                                "Maybe use '127.0.0.1' or '::1' instead."
+                            )
 
 #############################################
 #   __  __             _  __          _     #

--- a/package_linter.py
+++ b/package_linter.py
@@ -1531,6 +1531,31 @@ class Configurations(TestSuite):
                         % location
                     )
 
+    @test()
+    def bind_public_ip(self):
+        app = self.app
+        for filename in (
+            os.listdir(app.path + "/conf") if os.path.exists(app.path + "/conf") else []
+        ):
+            try:
+                content = open(app.path + "/conf/" + filename).read()
+            except Exception as e:
+                yield Warning("Can't open/read %s: %s" % (filename, e))
+                return
+
+            for line in content.split("\n"):
+                comment = ["#", "//", ";"]
+                if (
+                    "0.0.0.0" in line
+                    or "::" in line
+                    and not line.strip().startswith(comment)
+                ):
+                    yield Info(
+                        "%s: Binding to '0.0.0.0' or '::' can result in a security issue as "
+                        "the SSO can be bypassed by knowing a public IP (typically an IPv6) "
+                        "and the app port. Please be sure that this behavior is intentional.\n"
+                        "Maybe use '127.0.0.1' or '::1' instead." % filename
+                    )
 
 #############################################
 #   __  __             _  __          _     #

--- a/package_linter.py
+++ b/package_linter.py
@@ -1550,10 +1550,11 @@ class Configurations(TestSuite):
                     and not line.strip().startswith(comment)
                 ):
                     yield Info(
-                        f"{filename}:{number}: Binding to '0.0.0.0' or '::' can result in "
-                        "a security issue as the SSO can be bypassed by knowing a public "
-                        "IP (typically an IPv6) and the app port. Please be sure that this "
-                        "behavior is intentional. Maybe use '127.0.0.1' or '::1' instead."
+                        f"{filename}:{number}: Binding to '0.0.0.0' or '::' can result "
+                        "in a security issue as the reverse proxy and the SSO can be "
+                        "bypassed by knowing a public IP (typically an IPv6) and the "
+                        "app port. lease be sure that this behavior is intentional. "
+                        "Maybe use '127.0.0.1' or '::1' instead."
                     )
 
 #############################################

--- a/package_linter.py
+++ b/package_linter.py
@@ -1550,7 +1550,7 @@ class Configurations(TestSuite):
                     and not line.strip().startswith(comment)
                 ):
                     for ip in re.split("[ \t,='\"(){}\[\]]", line):
-                        if ip == "::" or ( "0.0.0.0" in ip and ip.startswith("0.0.0.0") ):
+                        if ip == "::" or ip.startswith("0.0.0.0"):
                             yield Info(
                                 f"{filename}:{number}: Binding to '0.0.0.0' or '::' can result "
                                 "in a security issue as the reverse proxy and the SSO can be "


### PR DESCRIPTION
check if a package config file uses `0.0.0.0` or `::` to bind IPs
if so, there is a risk of bind a public IP
this can result in a security issue as the SSO can be bypassed by knowing a public IP (typically an IPv6) and the app port.