### PR TITLE
Allow multiple whitespace after 'more_set_headers'

### DIFF
--- a/package_linter.py
+++ b/package_linter.py
@@ -1418,7 +1418,7 @@ class Configurations(TestSuite):
 
                 def right_syntax(line):
                     return re.search(
-                        r"more_set_headers [\"\'][\w-]+\s?: .*[\"\'];", line
+                        r"more_set_headers +[\"\'][\w-]+\s?: .*[\"\'];", line
                     )
 
                 if any(not right_syntax(line) for line in more_set_headers_lines):


### PR DESCRIPTION
While stupid `more_set_headers                              "Header: Value"` is a valid syntax.