### PR TITLE
Fix regex in helpers_sourcing_after_official()

### DIFF
--- a/package_linter.py
+++ b/package_linter.py
@@ -2797,7 +2797,7 @@ class Script(TestSuite):
     @test()
     def helpers_sourcing_after_official(self):
         helpers_after_official = subprocess.check_output(
-            "head -n 30 '%s' | grep -A 10 '^ *source */usr/share/yunohost/helpers' | grep '^ *source' | tail -n +2"
+            "head -n 30 '%s' | grep -A 10 '^ *source */usr/share/yunohost/helpers' | grep '^ *source ' | tail -n +2"
             % self.path,
             shell=True,
         ).decode("utf-8")


### PR DESCRIPTION
Current regex will match any of the ten line after the official helper files starting with the string `source`. 
Thus, in my specific case in an install script for which I declare a variable named `source_filename=$(basename $upstream_source_url)`, the linter will unecessarily display the following warning: `    ! Please avoid sourcing additional helpers after the official helpers (in this case file _filename=$(basename$upstream__url)) `.
As it should be only interested in matching the command `source` (`source path/to/file`), a space should be appended to the current regex.