### PR TITLE
Downgrade misc_nginx_check_regex_in_location from Warning to Info

### DIFF
--- a/package_linter.py
+++ b/package_linter.py
@@ -1448,7 +1448,7 @@ class Configurations(TestSuite):
             cmd = 'grep -q -IhEro "location ~ __PATH__" %s' % (app.path + "/conf/" + filename)
 
             if os.system(cmd) != 0:
-                yield Warning(
+                yield Info(
                     "When using regexp in the nginx location field (location ~ __PATH__), start the path with ^ (location ~ ^__PATH__)."
                 )
 


### PR DESCRIPTION
as talked with @Tagadda, the fact that it's a warning isn't very appropriate 