### PR TITLE
bind_public_ip: fix for .js config files

### DIFF
--- a/package_linter.py
+++ b/package_linter.py
@@ -1577,20 +1577,20 @@ class Configurations(TestSuite):
 
             for number, line in enumerate(content.split("\n"), 1):
                 comment = ("#", "//", ";", "/**", "*")
-                    if (
-                        ( "0.0.0.0" in line or "::" in line )
-                        and not line.strip().startswith(comment)
-                    ):
-                        for ip in re.split("[ \t,='\"(){}\[\]]", line):
-                            if ip == "::" or ip.startswith("0.0.0.0"):
-                                yield Info(
-                                    f"{os.path.relpath(path, app.path)}/{filename}:{number}: "
-                                    "Binding to '0.0.0.0' or '::' can result in a security issue "
-                                    "as the reverse proxy and the SSO can be bypassed by knowing "
-                                    "a public IP (typically an IPv6) and the app port. "
-                                    "Please be sure that this behavior is intentional. "
-                                    "Maybe use '127.0.0.1' or '::1' instead."
-                                )
+                if (
+                    ( "0.0.0.0" in line or "::" in line )
+                    and not line.strip().startswith(comment)
+                ):
+                    for ip in re.split("[ \t,='\"(){}\[\]]", line):
+                        if ip == "::" or ip.startswith("0.0.0.0"):
+                            yield Info(
+                                f"{os.path.relpath(path, app.path)}/{filename}:{number}: "
+                                "Binding to '0.0.0.0' or '::' can result in a security issue "
+                                "as the reverse proxy and the SSO can be bypassed by knowing "
+                                "a public IP (typically an IPv6) and the app port. "
+                                "Please be sure that this behavior is intentional. "
+                                "Maybe use '127.0.0.1' or '::1' instead."
+                            )
 
 #############################################
 #   __  __             _  __          _     #

--- a/package_linter.py
+++ b/package_linter.py
@@ -1575,7 +1575,7 @@ class Configurations(TestSuite):
                 return
 
             for number, line in enumerate(content.split("\n"), 1):
-                comment = ("#", "//", ";")
+                comment = ("#", "//", ";", "/**", "*")
                 if (
                     ( "0.0.0.0" in line or "::" in line )
                     and not line.strip().startswith(comment)

--- a/package_linter.py
+++ b/package_linter.py
@@ -1575,22 +1575,22 @@ class Configurations(TestSuite):
                     yield Warning("Can't open/read %s: %s" % (os.path.join(path, filename), e))
                     return
 
-            for number, line in enumerate(content.split("\n"), 1):
-                comment = ("#", "//", ";", "/**", "*")
-                if (
-                    ( "0.0.0.0" in line or "::" in line )
-                    and not line.strip().startswith(comment)
-                ):
-                    for ip in re.split("[ \t,='\"(){}\[\]]", line):
-                        if ip == "::" or ip.startswith("0.0.0.0"):
-                            yield Info(
-                                f"{os.path.relpath(path, app.path)}/{filename}:{number}: "
-                                "Binding to '0.0.0.0' or '::' can result in a security issue "
-                                "as the reverse proxy and the SSO can be bypassed by knowing "
-                                "a public IP (typically an IPv6) and the app port. "
-                                "Please be sure that this behavior is intentional. "
-                                "Maybe use '127.0.0.1' or '::1' instead."
-                            )
+                for number, line in enumerate(content.split("\n"), 1):
+                    comment = ("#", "//", ";", "/**", "*")
+                    if (
+                        ( "0.0.0.0" in line or "::" in line )
+                        and not line.strip().startswith(comment)
+                    ):
+                        for ip in re.split("[ \t,='\"(){}\[\]]", line):
+                            if ip == "::" or ip.startswith("0.0.0.0"):
+                                yield Info(
+                                    f"{os.path.relpath(path, app.path)}/{filename}:{number}: "
+                                    "Binding to '0.0.0.0' or '::' can result in a security issue "
+                                    "as the reverse proxy and the SSO can be bypassed by knowing "
+                                    "a public IP (typically an IPv6) and the app port. "
+                                    "Please be sure that this behavior is intentional. "
+                                    "Maybe use '127.0.0.1' or '::1' instead."
+                                )
 
 #############################################
 #   __  __             _  __          _     #

--- a/package_linter.py
+++ b/package_linter.py
@@ -1576,7 +1576,7 @@ class Configurations(TestSuite):
                     return
 
                 for number, line in enumerate(content.split("\n"), 1):
-                    comment = ("#", "//", ";", "/**", "*")
+                    comment = ("#", "//", ";", "/*", "*")
                     if (
                         ( "0.0.0.0" in line or "::" in line )
                         and not line.strip().startswith(comment)


### PR DESCRIPTION
## The problem:

> - settings.js:154: Binding to '0.0.0.0' or '::' can result in a security issue as the reverse proxy and the SSO can be bypassed by knowing a public IP (typically an IPv6) and the app port. lease be sure that this behavior is intentional. Maybe use '127.0.0.1' or '::1' instead.

https://ci-apps-dev.yunohost.org/ci/job/13846

The reported code is in fact a comment:
```
/** By default, the Node-RED UI accepts connections on all IPv4 interfaces.
* To listen on all IPv6 addresses, set uiHost to "::",
* The following property can be used to listen on a specific interface. For
* example, the following would only allow connections from the local machine.
*/
```
https://github.com/YunoHost-Apps/nodered_ynh/blob/master/conf/settings.js#L153C1-L157C8

## The fix

add javascript comment syntax (`/**` & `*`) to the linter logic