### PR TITLE
Fix nginx test

### DIFF
--- a/package_linter.py
+++ b/package_linter.py
@@ -1447,7 +1447,7 @@ class Configurations(TestSuite):
 
             cmd = 'grep -q -IhEro "location ~ __PATH__" %s' % (app.path + "/conf/" + filename)
 
-            if os.system(cmd) != 0:
+            if os.system(cmd) == 0:
                 yield Info(
                     "When using regexp in the nginx location field (location ~ __PATH__), start the path with ^ (location ~ ^__PATH__)."
                 )


### PR DESCRIPTION
grep will return 0 when it finds matches.
In our case, when it finds matches, we need to print the warning.