### PR TITLE
Fix bad_ynh_exec_syntax

### DIFF
--- a/package_linter.py
+++ b/package_linter.py
@@ -2513,7 +2513,7 @@ class Script(TestSuite):
 
     @test()
     def bad_ynh_exec_syntax(self):
-        cmd = 'grep -q -IhEro "ynh_exec_(err|warn|warn_less|quiet|fully_quiet) (\\"|\')" %s' % self.path
+        cmd = 'grep -q -IhEro "ynh_exec_(err|warn|warn_less|quiet|fully_quiet) (\\"|\').*(\\"|\')$" %s' % self.path
         if os.system(cmd) == 0:
             yield Warning("(Requires Yunohost 4.3) When using ynh_exec_*, please don't wrap your command between quotes (typically DONT write ynh_exec_warn_less 'foo --bar --baz')")
 


### PR DESCRIPTION
> ! (Requires Yunohost 4.3) When using ynh_exec_*, please don't wrap your command between quotes (typically DONT write ynh_exec_warn_less 'foo --bar --baz')

yeah but i don't:

`ynh_exec_warn_less "$install_dir/script/convos" install`

so adjusting the regex to check if the line also finishes with a quoting mark