### PR TITLE
Avoid ssowat config persistent error on /doc

### DIFF
--- a/package_linter.py
+++ b/package_linter.py
@@ -992,8 +992,8 @@ class App(TestSuite):
     def conf_json_persistent_tweaking(self):
         if (
             os.system(
-                "grep -q -nr '/etc/ssowat/conf.json.persistent' %s/*/* 2>/dev/null"
-                % self.path
+                "grep -nr '/etc/ssowat/conf.json.persistent' %s | grep -vq '^%s/doc' 2>/dev/null"
+                % (self.path, self.path)
             )
             == 0
         ):


### PR DESCRIPTION
# Problem

False positive on https://github.com/YunoHost-Apps/synapse_ynh/blob/6ed1dd9a9f73bce6c55040a5ae267c266577b201/doc/ADMIN.md#add-permanent-rule-on-ssowat

# Solution

Exclude `/etc/ssowat/conf.json.persistent` in `/doc` it's not black magick when it's documented