### PR TITLE
Fix showed path in 'bind_public_ip' message

### DIFF
--- a/package_linter.py
+++ b/package_linter.py
@@ -1584,10 +1584,11 @@ class Configurations(TestSuite):
                         for ip in re.split("[ \t,='\"(){}\[\]]", line):
                             if ip == "::" or ip.startswith("0.0.0.0"):
                                 yield Info(
-                                    f"{os.path.join(path, filename)}:{number}: Binding to '0.0.0.0' or '::' can result "
-                                    "in a security issue as the reverse proxy and the SSO can be "
-                                    "bypassed by knowing a public IP (typically an IPv6) and the "
-                                    "app port. lease be sure that this behavior is intentional. "
+                                    f"{os.path.relpath(path, app.path)}:{number}: "
+                                    "Binding to '0.0.0.0' or '::' can result in a security issue "
+                                    "as the reverse proxy and the SSO can be bypassed by knowing "
+                                    "a public IP (typically an IPv6) and the app port. "
+                                    "Please be sure that this behavior is intentional. "
                                     "Maybe use '127.0.0.1' or '::1' instead."
                                 )
 

--- a/package_linter.py
+++ b/package_linter.py
@@ -1584,7 +1584,7 @@ class Configurations(TestSuite):
                         for ip in re.split("[ \t,='\"(){}\[\]]", line):
                             if ip == "::" or ip.startswith("0.0.0.0"):
                                 yield Info(
-                                    f"{os.path.relpath(path, app.path)}:{number}: "
+                                    f"{os.path.relpath(path, app.path)}/{filename}:{number}: "
                                     "Binding to '0.0.0.0' or '::' can result in a security issue "
                                     "as the reverse proxy and the SSO can be bypassed by knowing "
                                     "a public IP (typically an IPv6) and the app port. "


### PR DESCRIPTION
## Problem

since #141, `bind_public_ip` returns unnecessarily long (and confusing) path:
`/tmp/package_check.O22Mlb/app_folder/conf/server.toml:5`

## Solution

fix this by showing the path from the app folder:
```
conf/blah:1
conf/test/bleh:1
```

## PR checklist

- [x] PR finished and ready to be reviewed
  