### PR TITLE
'sed -i' info: added mention of 'ynh_replace_string'

### DIFF
--- a/package_linter.py
+++ b/package_linter.py
@@ -2913,7 +2913,7 @@ class Script(TestSuite):
             r"sed\s+(-i|--in-place)\s+(-r\s+)?s"
         ) or self.containsregex(r"sed\s+s\S*\s+(-i|--in-place)"):
             yield Info(
-                "You should avoid using 'sed -i' for substitutions, please use 'ynh_add_config' instead"
+                "You should avoid using 'sed -i' for substitutions, please use 'ynh_replace_string' or 'ynh_add_config' instead"
             )
 
     @test()


### PR DESCRIPTION
## Problem

- `sed -i` is often used instead of `ynh_replace_string`, not `ynh_add_config`

## Solution

- added mention of `ynh_replace_string` before `ynh_add_config`

## PR checklist

- [x] PR finished and ready to be reviewed
  