### PR TITLE
makes level 8 disqualification explicit

### DIFF
--- a/package_linter.py
+++ b/package_linter.py
@@ -528,7 +528,7 @@ class App(TestSuite):
             ]
         ):
             _print(
-                " In the catalog, the app is flagged as not maintained / deprecated / alpha or replaced by another app"
+                " In the catalog, the app is flagged as not maintained / deprecated / alpha or replaced by another app, therefore does not qualify for level 8"
             )
         elif (
             "qualify_for_level_7" in successes


### PR DESCRIPTION
## Problem

- the level 8 disqualification message is not explicit on its stakes

## Solution

- edit it to make explicit why the package is disqualified for level 8

## PR checklist

- [x] PR finished and ready to be reviewed
  