### PR TITLE
When checking conf files, we need to ignore files that do not look like text files

### DIFF
--- a/tests/test_configurations.py
+++ b/tests/test_configurations.py
@@ -113,9 +113,10 @@ class Configurations(TestSuite):
                 content = open(app.path + "/conf/" + filename).read()
             except UnicodeDecodeError:
                 yield Info("%s does not look like a text file.")
+                continue
             except Exception as e:
                 yield Warning("Can't open/read %s : %s" % (filename, e))
-                return
+                continue
 
             if "[Unit]" not in content:
                 continue
@@ -130,7 +131,7 @@ class Configurations(TestSuite):
                 yield Level(
                     "You should specify a 'User=' directive in the systemd config !"
                 )
-                return
+                continue
 
             if any(match[1] in ["root", "www-data"] for match in matches):
                 yield Level(
@@ -182,9 +183,10 @@ class Configurations(TestSuite):
                 content = open(app.path + "/conf/" + filename).read()
             except UnicodeDecodeError:
                 yield Info("%s does not look like a text file.")
+                continue
             except Exception as e:
                 yield Warning("Can't open/read %s : %s" % (filename, e))
-                return
+                continue
 
             matches = re.findall(
                 r"^ *(user|group) = (\S+)", content, flags=re.MULTILINE
@@ -193,7 +195,7 @@ class Configurations(TestSuite):
                 yield Error(
                     "You should at least specify a 'user =' directive in your PHP conf file"
                 )
-                return
+                continue
 
             if any(
                 match[1] == "root" or match == ("user", "www-data") for match in matches
@@ -452,11 +454,12 @@ class Configurations(TestSuite):
                     content = open(os.path.join(path, filename)).read()
                 except UnicodeDecodeError:
                     yield Info("%s does not look like a text file.")
+                    continue
                 except Exception as e:
                     yield Warning(
                         "Can't open/read %s: %s" % (os.path.join(path, filename), e)
                     )
-                    return
+                    continue
 
                 for number, line in enumerate(content.split("\n"), 1):
                     comment = ("#", "//", ";", "/*", "*")

--- a/tests/test_configurations.py
+++ b/tests/test_configurations.py
@@ -111,6 +111,8 @@ class Configurations(TestSuite):
 
             try:
                 content = open(app.path + "/conf/" + filename).read()
+            except UnicodeDecodeError:
+                yield Info("%s does not look like a text file.")
             except Exception as e:
                 yield Warning("Can't open/read %s : %s" % (filename, e))
                 return
@@ -178,6 +180,8 @@ class Configurations(TestSuite):
 
             try:
                 content = open(app.path + "/conf/" + filename).read()
+            except UnicodeDecodeError:
+                yield Info("%s does not look like a text file.")
             except Exception as e:
                 yield Warning("Can't open/read %s : %s" % (filename, e))
                 return
@@ -446,6 +450,8 @@ class Configurations(TestSuite):
             for filename in files:
                 try:
                     content = open(os.path.join(path, filename)).read()
+                except UnicodeDecodeError:
+                    yield Info("%s does not look like a text file.")
                 except Exception as e:
                     yield Warning(
                         "Can't open/read %s: %s" % (os.path.join(path, filename), e)


### PR DESCRIPTION
In the whole catalog, we never saw 'Can't open/read ...' on real text files, so we can assume it's safe.

Closes #166 