### PR TITLE
do not consider a directory as a wrong screenshot file...

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -407,6 +407,8 @@ class App(TestSuite):
 
             for file in (app.path / "doc" / "screenshots").rglob("*"):
                 filename = file.name
+                if Path.is_dir(file):
+                    continue
                 if filename == ".gitkeep":
                     continue
                 if all(


### PR DESCRIPTION
## Problem

- if there is a sub-directory in the /doc/screenshot directory, the linter returns a false positive:
   > In the doc/screenshots folder, only .jpg, .jpeg, .png, .webp and .gif are accepted

## Solution

- do not try to check the extension of a directory...

## PR checklist

- [x] PR finished and ready to be reviewed
  