### PR TITLE
Initialize issues list in test_issues.py

### DIFF
--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -25,6 +25,7 @@ class Issues(TestSuite):
 
         self.app_list = get_app_list()
         repo_url = self.app_list[app]["url"]
+        self.issues = [] # init blank in case lines below fail
         if "github.com" not in repo_url:
             report_warning_not_reliable(
                 "Can't check if there are any blocking issues pending, can only do this for apps hosted on github for now."


### PR DESCRIPTION
## Problem

- https://ci-apps-dev.yunohost.org/ci/job/12213

```
    main()
  File "/var/www/yunorunner/package_check/./package_linter/package_linter.py", line 36, in main
    app.analyze()
  File "/var/www/yunorunner/package_check/package_linter/tests/test_app.py", line 269, in analyze
    self.issues.run_tests()
  File "/var/www/yunorunner/package_check/package_linter/lib/lib_package_linter.py", line 192, in run_tests
    this_test_reports = list(test(self))
                        ^^^^^^^^^^^^^^^^
  File "/var/www/yunorunner/package_check/package_linter/tests/test_issues.py", line 49, in issue_marked_as_linter_error
    for issue in self.issues
                 ^^^^^^^^^^^
AttributeError: 'Issues' object has no attribute 'issues'
```

## Solution

- Initialize `issues` collection even if checks below fail

## PR checklist

- [ ] PR finished and ready to be reviewed
  