### PR TITLE
Don't fail on packages from outside of the catalog

### DIFF
--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -24,7 +24,7 @@ class Issues(TestSuite):
         self.test_suite_name = "Issues"
 
         self.app_list = get_app_list()
-        repo_url = self.app_list[app]["url"]
+        repo_url = self.app_list.get(app, {}).get("url", "invalid")
         self.issues = []  # init blank in case lines below fail
         if "github.com" not in repo_url:
             report_warning_not_reliable(


### PR DESCRIPTION
## Problem

- https://ci-apps-dev.yunohost.org/ci/job/12415

```
Traceback (most recent call last):
  File "/var/www/yunorunner/package_check/./package_linter/package_linter.py", line 40, in <module>
    main()
  File "/var/www/yunorunner/package_check/./package_linter/package_linter.py", line 35, in main
    app = App(args.app_path)
          ^^^^^^^^^^^^^^^^^^
  File "/var/www/yunorunner/package_check/package_linter/tests/test_app.py", line 253, in __init__
    self.issues = Issues(self.manifest["id"])
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/www/yunorunner/package_check/package_linter/tests/test_issues.py", line 27, in __init__
    repo_url = self.app_list[app]["url"]
               ~~~~~~~~~~~~~^^^^^
KeyError: 'tuwunel'
```

## Solution

- `get(whatever, sane_default)`

## PR checklist

- [ ] PR finished and ready to be reviewed
  