### PR TITLE
don’t warn when sso=false but using proxy_params_with_auth

### DIFF
--- a/tests/test_configurations.py
+++ b/tests/test_configurations.py
@@ -494,10 +494,6 @@ class Configurations(TestSuite):
                 yield Warning(
                     "In manifest.toml, sso integration is set to true, but the nginx conf doesn't seem to include proxy_params_with_auth or fastcgi_params_with_auth."
                 )
-            elif sso in [False, "not_relevant"] and include_params_with_auth:
-                yield Warning(
-                    "In manifest.toml, sso integration is set to false or not_relevant, but the nginx conf seems to include proxy_params_with_auth or fastcgi_params_with_auth with suggest maybe it does?"
-                )
 
             reverse_proxy_params_from_includes = [
                 # Reverse proxy


### PR DESCRIPTION
## Problem

- *Description of why you made this PR, what is its purpose*

As mentioned in the chatroom
e.g. https://ci-apps.yunohost.org/ci/job/26398 where FitTrackee need the with_auth to be able to connect, but doesn’t have sso

## Solution

- *And how do you relevantly fix that problem*

## PR checklist

- [ ] PR finished and ready to be reviewed
  