### PR TITLE
[enh] Check curl_tests for webapps

### DIFF
--- a/tests/test_configurations.py
+++ b/tests/test_configurations.py
@@ -48,11 +48,27 @@ class Configurations(TestSuite):
                 "The 'check_process' file that interfaces with the app CI has now been replaced with 'tests.toml' format and is now mandatory for apps v2."
             )
         else:
+            tests_data = tomllib.load(tests_toml_file.open("rb"))
             yield from validate_schema(
                 "tests.toml",
                 json.loads(tests_v1_schema()),
-                tomllib.load(tests_toml_file.open("rb")),
+                tests_data,
             )
+
+            # Check curl_tests are configured for webapps
+            manifest_path = self.app.path / "manifest.toml"
+            try:
+                manifest_data = tomllib.load(manifest_path.open("rb"))
+                is_webapp = 'domain' in manifest_data.get('install', {})
+            except Exception:
+                is_webapp = True
+            if is_webapp and 'curl_tests' not in tests_data.get('default', {}):
+                yield Warning(
+                    "Web app tests.toml should run some curl_tests in order to validate "
+                    "the webapp is properly running.\n"
+                    "See: https://github.com/YunoHost/package_check?tab=readme-ov-file#curl-tests"
+                )
+
 
     @test()
     def encourage_extra_php_conf(self) -> TestResult:
@@ -82,7 +98,7 @@ class Configurations(TestSuite):
                 "See the helper documentation. "
                 "Original discussion happened here: "
                 "https://github.com/YunoHost/issues/issues/201#issuecomment-391549262"
-            )
+)
 
     @test()
     def systemd_config_specific_user(self) -> TestResult:

--- a/tests/test_configurations.py
+++ b/tests/test_configurations.py
@@ -56,14 +56,14 @@ class Configurations(TestSuite):
             )
 
             # Check curl_tests are configured for webapps
-            is_webapp = 'domain' in self.app.manifest.get('install', {})
+            cmd = f"grep -q -IhEr '^[^#]*ynh_config_add_nginx' '{self.app.path}/scripts/'"
+            is_webapp = os.system(cmd) == 0
             if is_webapp and 'curl_tests' not in tests_data.get('default', {}):
                 yield Warning(
                     "In tests.toml, you should add some curl_tests in order to"
                     "validate the webapp is properly running.\n"
                     "See: https://github.com/YunoHost/package_check?tab=readme-ov-file#curl-tests"
                 )
-
 
     @test()
     def encourage_extra_php_conf(self) -> TestResult:

--- a/tests/test_configurations.py
+++ b/tests/test_configurations.py
@@ -56,16 +56,11 @@ class Configurations(TestSuite):
             )
 
             # Check curl_tests are configured for webapps
-            manifest_path = self.app.path / "manifest.toml"
-            try:
-                manifest_data = tomllib.load(manifest_path.open("rb"))
-                is_webapp = 'domain' in manifest_data.get('install', {})
-            except Exception:
-                is_webapp = True
+            is_webapp = 'domain' in self.app.manifest.get('install', {})
             if is_webapp and 'curl_tests' not in tests_data.get('default', {}):
                 yield Warning(
-                    "Web app tests.toml should run some curl_tests in order to validate "
-                    "the webapp is properly running.\n"
+                    "In tests.toml, you should add some curl_tests in order to"
+                    "validate the webapp is properly running.\n"
                     "See: https://github.com/YunoHost/package_check?tab=readme-ov-file#curl-tests"
                 )
 

--- a/tests/test_configurations.py
+++ b/tests/test_configurations.py
@@ -98,7 +98,7 @@ class Configurations(TestSuite):
                 "See the helper documentation. "
                 "Original discussion happened here: "
                 "https://github.com/YunoHost/issues/issues/201#issuecomment-391549262"
-)
+            )
 
     @test()
     def systemd_config_specific_user(self) -> TestResult:


### PR DESCRIPTION
## Problem

When the CI say green we want to believe the app is properly running, however, it's not always the case.

## Solution

Attempt to reduce false green by asking packagers for adding curl_tests for all webapps

## Tests status
Tested on jitsi package
```
$ python3 ./package_linter.py ../apps/jitsi_ynh/
    [YunoHost App Package Linter]

 App packaging documentation - https://yunohost.org/packaging_apps
 App package example         - https://github.com/YunoHost/example_ynh
 Official helpers            - https://yunohost.org/packaging_apps_helpers

 If you believe this linter returns false negative (warnings / errors which shouldn't happen),
 please report them on https://github.com/YunoHost/package_linter/issues
    
  Analyzing app ../apps/jitsi_ynh ...

 ✔ manifest
 ✔ scripts/_common.sh
 ✔ scripts/install
 ✔ scripts/remove
 ✔ scripts/upgrade
 ✔ scripts/backup
 ✔ scripts/restore
 ✔ General stuff, misc helper usage
 ! Configuration files

    ! In tests.toml, you should add some curl_tests in order tovalidate the webapp is properly running.
See: https://github.com/YunoHost/package_check?tab=readme-ov-file#curl-tests 
    - You are encouraged to harden the security of the systemd configuration jitsi-videobridge.service. You can have a look at https://github.com/YunoHost/example_ynh/blob/main/conf/systemd.service#L14-L46 for a baseline.
    - You are encouraged to harden the security of the systemd configuration jitsi-jicofo.service. You can have a look at https://github.com/YunoHost/example_ynh/blob/main/conf/systemd.service#L14-L46 for a baseline.

 =======
 Only 1 warning remaining! You can do it!
```
## PR checklist

- [x] PR finished and ready to be reviewed
  