### PR TITLE
enh(licenses): require license_url if a custom license is used

### DIFF
--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -284,6 +284,8 @@ class Manifest(TestSuite):
                 return
 
             if license.startswith("LicenseRef-"):
+                if not self.manifest.get("upstream", {}).get("license_url"):
+                    yield Error("Missing 'license_url' key in the upstream section: it is required if you use a custom license id.")
                 yield Info(
                     "The license id '%s' is a custom one. This should be used only for 'not totally free' applications or FLOSS licenses not listed in https://spdx.org/licenses. Both cases should always be discussed with other contributors for validation."
                     % license


### PR DESCRIPTION
Related to https://github.com/YunoHost/issues/issues/2348
Dependent on https://github.com/YunoHost/apps/pull/3476

## PR checklist

- [x] PR finished and ready to be reviewed
  