### PR TITLE
docs: update README generator link

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -606,8 +606,8 @@ class App(TestSuite):
             )
         ):
             yield Warning(
-                "It looks like the README was not generated automatically by https://github.com/YunoHost/apps/tree/main/tools/README-generator. "
-                "Note that nowadays you are not suppose to edit README.md, the yunohost bot will usually automatically update it if your app is hosted in the YunoHost-Apps org ... or you can also generate it by running the README-generator yourself."
+                "It looks like the README was not generated automatically by https://github.com/YunoHost/apps_tools/tree/main/readme_generator. "
+                "Note that nowadays you are not supposed to edit README.md, the yunohost bot will usually automatically update it if your app is hosted in the YunoHost-Apps org ... or you can also generate it by running the README generator yourself."
             )
 
     @test()


### PR DESCRIPTION
## Problem

Fixes YunoHost/package_linter#190. The README warning points users to `YunoHost/apps/tree/main/tools/README-generator`, which now returns 404.

## Solution

Update the warning to the current `YunoHost/apps_tools/tree/main/readme_generator` location and clean up the adjacent wording from `suppose` to `supposed`.

## Verification

- Confirmed the old `YunoHost/apps/tree/main/tools/README-generator` URL returns HTTP 404.
- Confirmed the new `YunoHost/apps_tools/tree/main/readme_generator` URL returns HTTP 200.
- Ran `PYTHONPATH=. PATH="$HOME/.local/bin:$PATH" uv run --with pytest --with-requirements requirements.txt pytest tests/test_app.py -q`.
  - Result: `1 passed, 1 warning`.
  - The warning is the existing pytest warning for the repo's decorator-style `test` helper returning a function.
- Ran `git diff --check`.

## PR checklist

- [x] PR finished and ready to be reviewed